### PR TITLE
Optimizations for shared-memory Esirkepov implementation

### DIFF
--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -797,8 +797,6 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
-
-
             for (int k=dkl; k<=depos_order+2-dku; k++) {
                 for (int j=djl; j<=depos_order+2-dju; j++) {
                     amrex::Real sdxi = 0._rt;
@@ -811,7 +809,6 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                     }
                 }
             }
-
             for (int k=dkl; k<=depos_order+2-dku; k++) {
                 for (int i=dil; i<=depos_order+2-diu; i++) {
                     amrex::Real sdyj = 0._rt;
@@ -824,7 +821,6 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                     }
                 }
             }
-
             for (int j=djl; j<=depos_order+2-dju; j++) {
                 for (int i=dil; i<=depos_order+2-diu; i++) {
                     amrex::Real sdzk = 0._rt;

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -797,36 +797,42 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
+            amrex::Real sd = 0._rt;
+
             for (int k=dkl; k<=depos_order+2-dku; k++) {
-                for (int j=djl; j<=depos_order+2-dju; j++) {
-                    amrex::Real sdxi = 0._rt;
+                for (int j=djl; j<=depos_order+2-dju; j++, sd=0._rt) {
+#pragma unroll
                     for (int i=dil; i<=depos_order+1-diu; i++) {
-                        sdxi += wqx*(sx_old[i] - sx_new[i])*(
+                        sd += wqx*(sx_old[i] - sx_new[i])*(
                             one_third*(sy_new[j]*sz_new[k] + sy_old[j]*sz_old[k])
                            +one_sixth*(sy_new[j]*sz_old[k] + sy_old[j]*sz_new[k]));
-                        amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdxi);
+                        amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sd);
                     }
                 }
             }
+
+            sd = 0._rt;
             for (int k=dkl; k<=depos_order+2-dku; k++) {
-                for (int i=dil; i<=depos_order+2-diu; i++) {
-                    amrex::Real sdyj = 0._rt;
+                for (int i=dil; i<=depos_order+2-diu; i++, sd=0._rt) {
+#pragma unroll
                     for (int j=djl; j<=depos_order+1-dju; j++) {
-                        sdyj += wqy*(sy_old[j] - sy_new[j])*(
+                        sd += wqy*(sy_old[j] - sy_new[j])*(
                             one_third*(sx_new[i]*sz_new[k] + sx_old[i]*sz_old[k])
                            +one_sixth*(sx_new[i]*sz_old[k] + sx_old[i]*sz_new[k]));
-                        amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdyj);
+                        amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sd);
                     }
                 }
             }
+
+            sd = 0._rt;
             for (int j=djl; j<=depos_order+2-dju; j++) {
-                for (int i=dil; i<=depos_order+2-diu; i++) {
-                    amrex::Real sdzk = 0._rt;
+                for (int i=dil; i<=depos_order+2-diu; i++, sd=0._rt) {
+#pragma unroll
                     for (int k=dkl; k<=depos_order+1-dku; k++) {
-                        sdzk += wqz*(sz_old[k] - sz_new[k])*(
+                        sd += wqz*(sz_old[k] - sz_new[k])*(
                             one_third*(sx_new[i]*sy_new[j] + sx_old[i]*sy_old[j])
                            +one_sixth*(sx_new[i]*sy_old[j] + sx_old[i]*sy_new[j]));
-                        amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdzk);
+                        amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sd);
                     }
                 }
             }
@@ -1479,8 +1485,8 @@ void doEsirkepovDepositionSharedShapeN (const GetParticlePosition& GetPosition,
             unsigned int ip = permutation[ip_orig];
             depositEsirkepovComponentX<depos_order>(GetPosition, wp, uxp, uyp, uzp, ion_lev, jx_buff,// jx_type,
                                           dt, relative_time, dx, xyzmin, lo, q, n_rz_azimuthal_modes,
-                                          ip); 
-                                          //zdir, NODE, CELL, 
+                                          ip);
+                                          //zdir, NODE, CELL,
                                           //0);
         }
 
@@ -1500,7 +1506,7 @@ void doEsirkepovDepositionSharedShapeN (const GetParticlePosition& GetPosition,
             unsigned int ip = permutation[ip_orig];
             depositEsirkepovComponentY<depos_order>(GetPosition, wp, uxp, uyp, uzp, ion_lev, jy_buff,// jy_type,
                                           dt, relative_time, dx, xyzmin, lo, q, n_rz_azimuthal_modes,
-                                          ip); 
+                                          ip);
                                           //zdir, NODE, CELL,
                                           //1);
         }
@@ -1522,7 +1528,7 @@ void doEsirkepovDepositionSharedShapeN (const GetParticlePosition& GetPosition,
             depositEsirkepovComponentZ<depos_order>(GetPosition, wp, uxp, uyp, uzp, ion_lev, jz_buff, //jz_type,
                                           dt, relative_time, dx, xyzmin, lo, q, n_rz_azimuthal_modes,
                                           ip);
-                                          //zdir, NODE, CELL, 
+                                          //zdir, NODE, CELL,
                                           //2);
         }
 

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -800,7 +800,9 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
             for (int k=dkl; k<=depos_order+2-dku; k++) {
                 for (int j=djl; j<=depos_order+2-dju; j++) {
                     amrex::Real sdxi = 0._rt;
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 #pragma unroll
+#endif
                     for (int i=dil; i<=depos_order+1-diu; i++) {
                         sdxi += wqx*(sx_old[i] - sx_new[i])*(
                             one_third*(sy_new[j]*sz_new[k] + sy_old[j]*sz_old[k])
@@ -812,7 +814,9 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
             for (int k=dkl; k<=depos_order+2-dku; k++) {
                 for (int i=dil; i<=depos_order+2-diu; i++) {
                     amrex::Real sdyj = 0._rt;
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 #pragma unroll
+#endif
                     for (int j=djl; j<=depos_order+1-dju; j++) {
                         sdyj += wqy*(sy_old[j] - sy_new[j])*(
                             one_third*(sx_new[i]*sz_new[k] + sx_old[i]*sz_old[k])
@@ -824,7 +828,9 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
             for (int j=djl; j<=depos_order+2-dju; j++) {
                 for (int i=dil; i<=depos_order+2-diu; i++) {
                     amrex::Real sdzk = 0._rt;
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 #pragma unroll
+#endif
                     for (int k=dkl; k<=depos_order+1-dku; k++) {
                         sdzk += wqz*(sz_old[k] - sz_new[k])*(
                             one_third*(sx_new[i]*sy_new[j] + sx_old[i]*sy_old[j])

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -801,39 +801,39 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 
             for (int k=dkl; k<=depos_order+2-dku; k++) {
                 for (int j=djl; j<=depos_order+2-dju; j++) {
-                    amrex::Real sd = 0._rt;
+                    amrex::Real sdxi = 0._rt;
 #pragma unroll
                     for (int i=dil; i<=depos_order+1-diu; i++) {
-                        sd += wqx*(sx_old[i] - sx_new[i])*(
+                        sdxi += wqx*(sx_old[i] - sx_new[i])*(
                             one_third*(sy_new[j]*sz_new[k] + sy_old[j]*sz_old[k])
                            +one_sixth*(sy_new[j]*sz_old[k] + sy_old[j]*sz_new[k]));
-                        amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sd);
+                        amrex::Gpu::Atomic::AddNoRet( &Jx_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdxi);
                     }
                 }
             }
 
             for (int k=dkl; k<=depos_order+2-dku; k++) {
                 for (int i=dil; i<=depos_order+2-diu; i++) {
-                    amrex::Real sd = 0._rt;
+                    amrex::Real sdyj = 0._rt;
 #pragma unroll
                     for (int j=djl; j<=depos_order+1-dju; j++) {
-                        sd += wqy*(sy_old[j] - sy_new[j])*(
+                        sdyj += wqy*(sy_old[j] - sy_new[j])*(
                             one_third*(sx_new[i]*sz_new[k] + sx_old[i]*sz_old[k])
                            +one_sixth*(sx_new[i]*sz_old[k] + sx_old[i]*sz_new[k]));
-                        amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sd);
+                        amrex::Gpu::Atomic::AddNoRet( &Jy_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdyj);
                     }
                 }
             }
 
             for (int j=djl; j<=depos_order+2-dju; j++) {
                 for (int i=dil; i<=depos_order+2-diu; i++) {
-                    amrex::Real sd = 0._rt;
+                    amrex::Real sdzk = 0._rt;
 #pragma unroll
                     for (int k=dkl; k<=depos_order+1-dku; k++) {
-                        sd += wqz*(sz_old[k] - sz_new[k])*(
+                        sdzk += wqz*(sz_old[k] - sz_new[k])*(
                             one_third*(sx_new[i]*sy_new[j] + sx_old[i]*sy_old[j])
                            +one_sixth*(sx_new[i]*sy_old[j] + sx_old[i]*sy_new[j]));
-                        amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sd);
+                        amrex::Gpu::Atomic::AddNoRet( &Jz_arr(lo.x+i_new-1+i, lo.y+j_new-1+j, lo.z+k_new-1+k), sdzk);
                     }
                 }
             }

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -797,10 +797,11 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
-            amrex::Real sd = 0._rt;
+
 
             for (int k=dkl; k<=depos_order+2-dku; k++) {
-                for (int j=djl; j<=depos_order+2-dju; j++, sd=0._rt) {
+                for (int j=djl; j<=depos_order+2-dju; j++) {
+                    amrex::Real sd = 0._rt;
 #pragma unroll
                     for (int i=dil; i<=depos_order+1-diu; i++) {
                         sd += wqx*(sx_old[i] - sx_new[i])*(
@@ -811,9 +812,9 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                 }
             }
 
-            sd = 0._rt;
             for (int k=dkl; k<=depos_order+2-dku; k++) {
-                for (int i=dil; i<=depos_order+2-diu; i++, sd=0._rt) {
+                for (int i=dil; i<=depos_order+2-diu; i++) {
+                    amrex::Real sd = 0._rt;
 #pragma unroll
                     for (int j=djl; j<=depos_order+1-dju; j++) {
                         sd += wqy*(sy_old[j] - sy_new[j])*(
@@ -824,9 +825,9 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition& GetPosition,
                 }
             }
 
-            sd = 0._rt;
             for (int j=djl; j<=depos_order+2-dju; j++) {
-                for (int i=dil; i<=depos_order+2-diu; i++, sd=0._rt) {
+                for (int i=dil; i<=depos_order+2-diu; i++) {
+                    amrex::Real sd = 0._rt;
 #pragma unroll
                     for (int k=dkl; k<=depos_order+1-dku; k++) {
                         sd += wqz*(sz_old[k] - sz_new[k])*(

--- a/Source/Particles/Deposition/SharedDepositionUtils.H
+++ b/Source/Particles/Deposition/SharedDepositionUtils.H
@@ -1056,7 +1056,6 @@ void depositEsirkepovComponentY (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
-
     for (int k=dkl; k<=depos_order+2-dku; k++) {
         for (int i=dil; i<=depos_order+2-diu; i++) {
             amrex::Real sdyj = 0._rt;

--- a/Source/Particles/Deposition/SharedDepositionUtils.H
+++ b/Source/Particles/Deposition/SharedDepositionUtils.H
@@ -640,7 +640,7 @@ void depositEsirkepovComponentX (const GetParticlePosition& GetPosition,
                        const amrex::Real q,
                        const int n_rz_azimuthal_modes,
                        const unsigned int ip)
-                       //const int zdir, const int NODE, const int CELL, 
+                       //const int zdir, const int NODE, const int CELL,
                        //const int dir)
 {
 #if !defined(WARPX_DIM_RZ)
@@ -810,9 +810,10 @@ void depositEsirkepovComponentX (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
+    amrex::Real sdxi = 0._rt;
     for (int k=dkl; k<=depos_order+2-dku; k++) {
-        for (int j=djl; j<=depos_order+2-dju; j++) {
-            amrex::Real sdxi = 0._rt;
+        for (int j=djl; j<=depos_order+2-dju; j++, sdxi = 0._rt) {
+#pragma unroll
             for (int i=dil; i<=depos_order+1-diu; i++) {
                 sdxi += wqx*(sx_old[i] - sx_new[i])*(
                     one_third*(sy_new[j]*sz_new[k] + sy_old[j]*sz_old[k])
@@ -870,7 +871,7 @@ void depositEsirkepovComponentY (const GetParticlePosition& GetPosition,
                        const amrex::Real q,
                        const int n_rz_azimuthal_modes,
                        const unsigned int ip)
-                       //const int zdir, const int NODE, const int CELL, 
+                       //const int zdir, const int NODE, const int CELL,
                        //const int dir)
 {
 #if !defined(WARPX_DIM_RZ)
@@ -1055,9 +1056,10 @@ void depositEsirkepovComponentY (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
+    amrex::Real sdyj = 0._rt;
     for (int k=dkl; k<=depos_order+2-dku; k++) {
-        for (int i=dil; i<=depos_order+2-diu; i++) {
-            amrex::Real sdyj = 0._rt;
+        for (int i=dil; i<=depos_order+2-diu; i++, sdyj = 0._rt) {
+#pragma unroll
             for (int j=djl; j<=depos_order+1-dju; j++) {
                 sdyj += wqy*(sy_old[j] - sy_new[j])*(
                     one_third*(sx_new[i]*sz_new[k] + sx_old[i]*sz_old[k])
@@ -1291,9 +1293,11 @@ void depositEsirkepovComponentZ (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
+    amrex::Real sdzk = 0._rt;
+
     for (int j=djl; j<=depos_order+2-dju; j++) {
-        for (int i=dil; i<=depos_order+2-diu; i++) {
-            amrex::Real sdzk = 0._rt;
+        for (int i=dil; i<=depos_order+2-diu; i++, sdzk = 0._rt) {
+#pragma unroll
             for (int k=dkl; k<=depos_order+1-dku; k++) {
                 sdzk += wqz*(sz_old[k] - sz_new[k])*(
                     one_third*(sx_new[i]*sy_new[j] + sx_old[i]*sy_old[j])

--- a/Source/Particles/Deposition/SharedDepositionUtils.H
+++ b/Source/Particles/Deposition/SharedDepositionUtils.H
@@ -810,9 +810,9 @@ void depositEsirkepovComponentX (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
-    amrex::Real sdxi = 0._rt;
     for (int k=dkl; k<=depos_order+2-dku; k++) {
-        for (int j=djl; j<=depos_order+2-dju; j++, sdxi = 0._rt) {
+        for (int j=djl; j<=depos_order+2-dju; j++) {
+            amrex::Real sdxi = 0._rt;
 #pragma unroll
             for (int i=dil; i<=depos_order+1-diu; i++) {
                 sdxi += wqx*(sx_old[i] - sx_new[i])*(
@@ -1056,9 +1056,10 @@ void depositEsirkepovComponentY (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
-    amrex::Real sdyj = 0._rt;
+
     for (int k=dkl; k<=depos_order+2-dku; k++) {
-        for (int i=dil; i<=depos_order+2-diu; i++, sdyj = 0._rt) {
+        for (int i=dil; i<=depos_order+2-diu; i++) {
+            amrex::Real sdyj = 0._rt;
 #pragma unroll
             for (int j=djl; j<=depos_order+1-dju; j++) {
                 sdyj += wqy*(sy_old[j] - sy_new[j])*(
@@ -1293,10 +1294,9 @@ void depositEsirkepovComponentZ (const GetParticlePosition& GetPosition,
 
 #if defined(WARPX_DIM_3D)
 
-    amrex::Real sdzk = 0._rt;
-
     for (int j=djl; j<=depos_order+2-dju; j++) {
-        for (int i=dil; i<=depos_order+2-diu; i++, sdzk = 0._rt) {
+        for (int i=dil; i<=depos_order+2-diu; i++) {
+            amrex::Real sdzk = 0._rt;
 #pragma unroll
             for (int k=dkl; k<=depos_order+1-dku; k++) {
                 sdzk += wqz*(sz_old[k] - sz_new[k])*(

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -561,6 +561,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
     // If not doing shared memory deposition, call normal kernels
     else {
         if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Esirkepov) {
+            WARPX_PROFILE_VAR_START(esirkepov_current_dep_kernel);
             if        (WarpX::nox == 1){
                 doEsirkepovDepositionShapeN<1>(
                     GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
@@ -583,6 +584,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
                     WarpX::n_rz_azimuthal_modes, cost,
                     WarpX::load_balance_costs_update_algo);
             }
+            WARPX_PROFILE_VAR_STOP(esirkepov_current_dep_kernel);
         } else if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay) {
             if        (WarpX::nox == 1){
                 doVayDepositionShapeN<1>(
@@ -607,6 +609,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
                     WarpX::load_balance_costs_update_algo);
             }
         } else { // Direct deposition
+            WARPX_PROFILE_VAR_START(direct_current_dep_kernel);
             if        (WarpX::nox == 1){
                 doDepositionShapeN<1>(
                     GetPosition, wp.dataPtr() + offset, uxp.dataPtr() + offset,
@@ -629,6 +632,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
                     xyzmin, lo, q, WarpX::n_rz_azimuthal_modes, cost,
                     WarpX::load_balance_costs_update_algo);
             }
+            WARPX_PROFILE_VAR_STOP(direct_current_dep_kernel);
         }
     }
     WARPX_PROFILE_VAR_STOP(blp_deposit);


### PR DESCRIPTION
Includes optimizations for shared memory implementation of Esirkepov current deposition kernel. The optimizations provide a **22% speed improvement** as seen below:

Before: 
<img width="844" alt="image" src="https://github.com/atmyers/WarpX/assets/14217455/4785ece7-aa6d-45dc-9be0-18431aabd17c">

After:
<img width="837" alt="image" src="https://github.com/atmyers/WarpX/assets/14217455/0bedabd1-3424-4d34-ae66-04450781613f">
